### PR TITLE
Display notes beside team composition

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,15 +234,18 @@
                       {Array.from(selectedDefense.offenses.values()).map(o => {
                         const wr = o.total ? Math.round((o.wins/o.total)*100) : 0;
                         const k = trioKey(o.offense);
+                        const notes = o.notes.join("; ");
                         return (
                           <div key={k} style={{padding:"4px 0"}}>
                             <div className="row" style={{justifyContent:"space-between"}}>
-                              <div>{o.offense.join(" · ")}</div>
+                              <div>
+                                {o.offense.join(" · ")}
+                                {notes && (
+                                  <span className="muted" style={{marginLeft:8}}>– {notes}</span>
+                                )}
+                              </div>
                               <div className="muted">{o.total} fights • WR {wr}%</div>
                             </div>
-                            {o.notes.map((note, i) => (
-                              <div key={i} className="muted" style={{marginLeft:12}}>- {note}</div>
-                            ))}
                           </div>
                         );
                       })}


### PR DESCRIPTION
## Summary
- show offensive team notes inline next to team composition

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b7fc5e8883238865c5dceb1ed870