### PR TITLE
feat: enable attack deletion from web

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,23 @@
         });
       }
 
+      // Delete a fight entry from Google Sheets
+      function deleteEntryFromSheet(id, setRows){
+        fetch(GOOGLE_WEB_APP_URL, {
+          method: 'POST',
+          body: JSON.stringify({ action: 'delete', id }),
+          headers: {'Content-Type': 'application/json'}
+        })
+        .then(response => response.text())
+        .then(data => {
+          alert(data);
+          fetchSheetData(setRows);
+        })
+        .catch(err => {
+          alert("Failed to delete entry: " + err);
+        });
+      }
+
       function App(){
         const [rows, setRows] = useState([]);
         const [searchDefense, setSearchDefense] = useState("");
@@ -166,7 +183,9 @@
         }
 
         function deleteEntry(id){
-          alert("To delete an entry, please remove it manually in the Google Sheet."); // Google Apps Script would need extension to support deletion
+          if(confirm("Delete this entry?")){
+            deleteEntryFromSheet(id, setRows);
+          }
         }
 
         return (


### PR DESCRIPTION
## Summary
- Allow deleting fight entries directly from the tracker UI
- Send delete requests to backend and refresh history after removal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c546a56bbc8323bd1abce75180ef8f